### PR TITLE
fix: omit error if file does not exist

### DIFF
--- a/examples/basic/original/index.html
+++ b/examples/basic/original/index.html
@@ -2,6 +2,10 @@
 <html lang="en">
   <head>
     <meta charset="utf-8">
+    <link
+      rel="stylesheet"
+      href="https://fonts.googleapis.com/css?family=Open+Sans:400,400i,600,600i,700,700i"
+    />
     <link rel="stylesheet" href="stylesheet.css">
   </head>
   <body>

--- a/examples/basic/package.json
+++ b/examples/basic/package.json
@@ -10,6 +10,6 @@
   "devDependencies": {
     "fs-extra": "^8.1.0",
     "posthtml": "^0.11.4",
-    "posthtml-hash": "^0.2.0"
+    "posthtml-hash": "../../"
   }
 }

--- a/examples/basic/processed/index.html
+++ b/examples/basic/processed/index.html
@@ -2,6 +2,7 @@
 <html lang="en">
   <head>
     <meta charset="utf-8">
+    <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Open+Sans:400,400i,600,600i,700,700i">
     <link rel="stylesheet" href="stylesheet.9a6cf95c41e87b9dc102.css">
   </head>
   <body>

--- a/examples/basic/yarn.lock
+++ b/examples/basic/yarn.lock
@@ -101,13 +101,11 @@ object-assign@^4.1.1:
   resolved "https://registry.yarnpkg.com/object-assign/-/object-assign-4.1.1.tgz#2109adc7965887cfc05cbbd442cac8bfbb360863"
   integrity sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=
 
-posthtml-hash@^0.2.0:
-  version "0.2.0"
-  resolved "https://registry.yarnpkg.com/posthtml-hash/-/posthtml-hash-0.2.0.tgz#ffa0efd8f410d09b00b896a552ee1360f0ae4595"
-  integrity sha512-/JHklA+7mCfVhyvzwudyzlsdqFo+A3lfe57xq6u8YBv8pM0jB05B83OlZgAO0D9yY0AsVMAYWzZ67BzuEE8nHA==
+posthtml-hash@../../:
+  version "0.2.2"
   dependencies:
     hasha "^5.0.0"
-    posthtml "^0.11.4"
+    posthtml "^0.12.0"
 
 posthtml-parser@^0.4.1:
   version "0.4.1"
@@ -126,6 +124,14 @@ posthtml@^0.11.4:
   version "0.11.4"
   resolved "https://registry.yarnpkg.com/posthtml/-/posthtml-0.11.4.tgz#26784d005d57d7aea93ab06dda899d59bdf186c7"
   integrity sha512-ezlzBkoPoRgh0jkmT1dsM8eT+lr2azyZ546kbda8oHnVnzvyaB3Ywo6UxUz8wPSOkFAAflCxZJhvvpQH1F6qcA==
+  dependencies:
+    posthtml-parser "^0.4.1"
+    posthtml-render "^1.1.5"
+
+posthtml@^0.12.0:
+  version "0.12.0"
+  resolved "https://registry.yarnpkg.com/posthtml/-/posthtml-0.12.0.tgz#6e2a2fcd774eaed1a419a95c5cc3a92b676a40a6"
+  integrity sha512-aNUEP/SfKUXAt+ghG51LC5MmafChBZeslVe/SSdfKIgLGUVRE68mrMF4V8XbH07ZifM91tCSuxY3eHIFLlecQw==
   dependencies:
     posthtml-parser "^0.4.1"
     posthtml-render "^1.1.5"

--- a/src/tests/utils.spec.ts
+++ b/src/tests/utils.spec.ts
@@ -49,20 +49,30 @@ describe('hashFileName', () => {
 });
 
 describe('processFile', () => {
-  it('throws an error if the file does not exist', () => {
+  it('does not invoke the callback if the file does not exist', () => {
     const fileName = path.join(__dirname, '__fixtures__/original', 'bundle.js');
-    expect(() => {
-      processFile(fileName, () => true);
-    }).toThrowError(`Could not find file at "${fileName}"`);
+    const cb = jest.fn();
+
+    processFile(fileName, cb);
+    expect(cb).not.toHaveBeenCalled();
+  });
+
+  it('does not invoke the callback if the file is a URL', () => {
+    const fileName = 'https://fonts.googleapis.com';
+    const cb = jest.fn();
+
+    processFile(fileName, cb);
+    expect(cb).not.toHaveBeenCalled();
   });
 
   it('invokes the callback if the file exists', () => {
-    const cb = jest.fn();
     const fileName = path.join(
       __dirname,
       '__fixtures__/original',
       'bundle.min.js'
     );
+    const cb = jest.fn();
+
     processFile(fileName, cb);
     expect(cb).toHaveBeenCalledTimes(1);
   });

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -22,8 +22,6 @@ function hashFileName(fileName: string, hash: string) {
 function processFile(file: string, cb: () => void) {
   if (fs.existsSync(file)) {
     cb.call([]);
-  } else {
-    throw new Error(`Could not find file at "${file}"`);
   }
 }
 


### PR DESCRIPTION
Fixes #22

## Bug Description

An HTML file containing a link to an external stylesheet throws an error, which kills the execution of the plugin. As a result, the static files are incompletely hashed (if at all).

## Problem

The error is thrown when reading the file in the [`processFile` utility](https://github.com/posthtml/posthtml-hash/blob/master/src/utils.ts#L26). Although the existence of the file should be checked, the unintended consequence of throwing an error is that it would stop execution of the plugin.

## Solution

The solution is to simply omit throwing an error if the file does not exist. In the future, it may still be useful to log warnings or a "success" message.

Another solution is to use a regex to exclude nodes that include "http" or "https" in the URI. However, simply checking for file existence would invalidate external URLs.

## Changes

- omit throwing an error in `processFile`
- update unit tests for `processFile`
- update the basic example to include an external stylesheet

## Postmortem

This bug represents a **classic failure in the lack of integration testing**.

The unit testing was comprehensive (100% coverage). What's more, throwing an error if the file does not exist works as intended.

However, in real application, there would be multiple files to be hashed, some of which could include external resources. Therefore, the execution of the plugin should not be stopped if one file cannot be hashed.