### PR TITLE
v0.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,11 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
-- Remove unhashed asset files, or require an "outDir" option
-
 - Add optional files field to options parameter that matches specific file names
 
 - Incorporate the `[hash:number]` format to specify the hash length
+
+## [0.3.0](https://github.com/metonym/posthtml-hash/releases/tag/v0.3.0) - 2020-05-04
+
+- Support omitting CSS/JS files to hash in `options`
 
 ## [0.2.3](https://github.com/metonym/posthtml-hash/releases/tag/v0.2.3) - 2019-12-27
 

--- a/README.md
+++ b/README.md
@@ -1,8 +1,6 @@
 # posthtml-hash <img align="right" width="220" height="200" title="PostHTML logo" src="http://posthtml.github.io/posthtml/logo.svg">
 
 [![NPM][npm]][npm-url]
-[![Build][build]][build-badge]
-[![Coverage][codecov-shield]][codecov]
 
 `posthtml-hash` is a [PostHTML](https://github.com/posthtml/posthtml) plugin for hashing static CSS/JS assets to enable caching. [hasha](https://www.npmjs.com/package/hasha) is used to generate hashes.
 
@@ -59,13 +57,22 @@ posthtml()
       /**
        * Relative path to processed HTML file
        */
-      path: "public",
+      path: "public", // default: ""
 
       /**
        * Length of hash
-       * Default is 20
        */
-      hashLength: 10,
+      hashLength: 10, // default: 20
+
+      /**
+       * Hash CSS files
+       */
+      css: true, // default: true
+
+      /**
+       * Hash JS files
+       */
+      js: true, // default: true
     })
   )
   .process(html)
@@ -86,7 +93,3 @@ See the [PostHTML Guidelines](https://github.com/posthtml/posthtml/tree/master/d
 
 [npm]: https://img.shields.io/npm/v/posthtml-hash.svg?color=blue
 [npm-url]: https://npmjs.com/package/posthtml-hash
-[build]: https://travis-ci.com/posthtml/posthtml-hash.svg?branch=master
-[build-badge]: https://travis-ci.com/posthtml/posthtml-hash
-[codecov]: https://codecov.io/gh/posthtml/posthtml-hash
-[codecov-shield]: https://img.shields.io/codecov/c/github/posthtml/posthtml-hash.svg

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "posthtml-hash",
-  "version": "0.2.3",
+  "version": "0.3.0",
   "license": "MIT",
   "description": "PostHTML plugin for hashing static assets",
   "author": "Eric Liu (https://github.com/metonym)",

--- a/src/global.d.ts
+++ b/src/global.d.ts
@@ -1,0 +1,1 @@
+declare module "is-match";

--- a/src/tests/__snapshots__/plugin.spec.ts.snap
+++ b/src/tests/__snapshots__/plugin.spec.ts.snap
@@ -1,5 +1,19 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`posthtml-hash matches the snapshot – css only 1`] = `
+"
+        <html>
+          <head>
+            <link rel=\\"stylesheet\\" href=\\"https://fonts.googleapis.com/css?family=Open+Sans:400,400i,600,600i,700,700i\\">
+            <link rel=\\"stylesheet\\" href=\\"bundle.min.9a6cf95c41e87b9dc102.css\\">
+          </head>
+          <body>
+            <script src=\\"bundle.min.js\\"></script>
+          </body>
+        </html>
+      "
+`;
+
 exports[`posthtml-hash matches the snapshot – custom hash length 1`] = `
 "
         <html>
@@ -21,6 +35,34 @@ exports[`posthtml-hash matches the snapshot – default options 1`] = `
           </head>
           <body>
             <script src=\\"bundle.min.b0dcc67ffc1fd562f212.js\\"></script>
+          </body>
+        </html>
+      "
+`;
+
+exports[`posthtml-hash matches the snapshot – js only 1`] = `
+"
+        <html>
+          <head>
+            <link rel=\\"stylesheet\\" href=\\"https://fonts.googleapis.com/css?family=Open+Sans:400,400i,600,600i,700,700i\\">
+            <link rel=\\"stylesheet\\" href=\\"bundle.min.css\\">
+          </head>
+          <body>
+            <script src=\\"bundle.min.b0dcc67ffc1fd562f212.js\\"></script>
+          </body>
+        </html>
+      "
+`;
+
+exports[`posthtml-hash matches the snapshot – no hash 1`] = `
+"
+        <html>
+          <head>
+            <link rel=\\"stylesheet\\" href=\\"https://fonts.googleapis.com/css?family=Open+Sans:400,400i,600,600i,700,700i\\">
+            <link rel=\\"stylesheet\\" href=\\"bundle.min.css\\">
+          </head>
+          <body>
+            <script src=\\"bundle.min.js\\"></script>
           </body>
         </html>
       "

--- a/src/tests/plugin.spec.ts
+++ b/src/tests/plugin.spec.ts
@@ -1,26 +1,30 @@
-import fs from 'fs';
-import path from 'path';
-import posthtml from 'posthtml';
-import plugin from '../';
+import fs from "fs";
+import path from "path";
+import posthtml from "posthtml";
+import plugin from "../";
 
-describe('posthtml-hash', () => {
+describe("posthtml-hash", () => {
   beforeEach(() => {
     const folder = {
-      input: '__fixtures__/original',
-      output: '__fixtures__/processed'
+      input: "__fixtures__/original",
+      output: "__fixtures__/processed",
     };
 
-    copyFixture('bundle.min.css', folder);
-    copyFixture('bundle.min.js', folder);
+    copyFixture("bundle.min.css", folder);
+    copyFixture("bundle.min.js", folder);
   });
 
-  it('matches the snapshot – default options', () => {
+  it("matches the snapshot – css only", () => {
     posthtml()
-      .use(plugin({ path: 'src/tests/__fixtures__/processed' }))
+      .use(plugin({ path: "src/tests/__fixtures__/processed", js: false }))
       .process(
         `
         <html>
           <head>
+            <link
+              rel="stylesheet"
+              href="https://fonts.googleapis.com/css?family=Open+Sans:400,400i,600,600i,700,700i"
+            />
             <link rel="stylesheet" href="bundle.min.css" />
           </head>
           <body>
@@ -29,14 +33,68 @@ describe('posthtml-hash', () => {
         </html>
       `
       )
-      .then(result => {
+      .then((result) => {
         expect(result.html).toMatchSnapshot();
       });
   });
 
-  it('matches the snapshot – custom hash length', () => {
+  it("matches the snapshot – js only", () => {
     posthtml()
-      .use(plugin({ path: 'src/tests/__fixtures__/processed', hashLength: 10 }))
+      .use(plugin({ path: "src/tests/__fixtures__/processed", css: false }))
+      .process(
+        `
+        <html>
+          <head>
+            <link
+              rel="stylesheet"
+              href="https://fonts.googleapis.com/css?family=Open+Sans:400,400i,600,600i,700,700i"
+            />
+            <link rel="stylesheet" href="bundle.min.css" />
+          </head>
+          <body>
+            <script src="bundle.min.js"></script>
+          </body>
+        </html>
+      `
+      )
+      .then((result) => {
+        expect(result.html).toMatchSnapshot();
+      });
+  });
+
+  it("matches the snapshot – no hash", () => {
+    posthtml()
+      .use(
+        plugin({
+          path: "src/tests/__fixtures__/processed",
+          css: false,
+          js: false,
+        })
+      )
+      .process(
+        `
+        <html>
+          <head>
+            <link
+              rel="stylesheet"
+              href="https://fonts.googleapis.com/css?family=Open+Sans:400,400i,600,600i,700,700i"
+            />
+            <link rel="stylesheet" href="bundle.min.css" />
+          </head>
+          <body>
+            <script src="bundle.min.js"></script>
+          </body>
+        </html>
+      `
+      )
+      .then((result) => {
+        expect(result.html).toMatchSnapshot();
+      });
+  });
+
+  it("matches the snapshot – default options", () => {
+    posthtml()
+      .use(plugin({ path: "src/tests/__fixtures__/processed" }))
       .process(
         `
         <html>
@@ -49,7 +107,27 @@ describe('posthtml-hash', () => {
         </html>
       `
       )
-      .then(result => {
+      .then((result) => {
+        expect(result.html).toMatchSnapshot();
+      });
+  });
+
+  it("matches the snapshot – custom hash length", () => {
+    posthtml()
+      .use(plugin({ path: "src/tests/__fixtures__/processed", hashLength: 10 }))
+      .process(
+        `
+        <html>
+          <head>
+            <link rel="stylesheet" href="bundle.min.css" />
+          </head>
+          <body>
+            <script src="bundle.min.js"></script>
+          </body>
+        </html>
+      `
+      )
+      .then((result) => {
         expect(result.html).toMatchSnapshot();
       });
   });


### PR DESCRIPTION
Support omitting CSS/JS files to hash. Closes #38 

**Hash CSS files only**

```js
plugin({ js: false })
```

**Hash JS files only**

```js
plugin({ css: false })
```